### PR TITLE
fix: prevent panic when opening stats/logs from groups, compose, and network tabs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1477,14 +1477,16 @@ func removeContainerFromGroup(gm *config.GroupManager, groupID, containerID stri
 }
 
 func startLogStreaming(client *docker.Client, logsView *views.LogsView, container *models.Container) tea.Cmd {
+	// Set container synchronously to reset the view state before the async Cmd runs
+	// This prevents race conditions where View() is called with stale data
+	logsView.SetContainer(container.ID, container.Name)
+
 	return func() tea.Msg {
 		if client == nil {
 			return nil
 		}
 
 		ctx := context.Background()
-		logsView.SetContainer(container.ID, container.Name)
-
 		logsChan, errorChan := client.StreamLogs(ctx, container.ID, true, time.Time{}, "100")
 		logsView.StartStreaming(logsChan, errorChan)
 
@@ -1511,14 +1513,16 @@ func waitForLogEntry(logsChan <-chan docker.LogEntry, errorChan <-chan error) te
 }
 
 func startStatsStreaming(client *docker.Client, statsView *views.StatsView, container *models.Container) tea.Cmd {
+	// Set container synchronously to reset the view state before the async Cmd runs
+	// This prevents race conditions where View() is called with stale data
+	statsView.SetContainer(container.ID, container.Name)
+
 	return func() tea.Msg {
 		if client == nil {
 			return nil
 		}
 
 		ctx := context.Background()
-		statsView.SetContainer(container.ID, container.Name)
-
 		statsChan, errorChan := client.StreamStats(ctx, container.ID)
 		statsView.StartStreaming(statsChan, errorChan)
 

--- a/internal/ui/views/logs.go
+++ b/internal/ui/views/logs.go
@@ -44,6 +44,7 @@ func (v *LogsView) SetContainer(containerID, containerName string) {
 	v.containerID = containerID
 	v.containerName = containerName
 	v.lines = []string{}
+	v.ready = false // Reset ready so View() shows loading state until StartStreaming is called
 }
 
 // StartStreaming starts streaming logs
@@ -121,7 +122,11 @@ func (v *LogsView) View() string {
 	var b strings.Builder
 
 	// Header
-	title := fmt.Sprintf("Logs: %s (%s)", v.containerName, v.containerID[:12])
+	shortID := v.containerID
+	if len(shortID) > 12 {
+		shortID = shortID[:12]
+	}
+	title := fmt.Sprintf("Logs: %s (%s)", v.containerName, shortID)
 	b.WriteString(styles.TitleStyle.Render(title))
 	b.WriteString("\n")
 

--- a/internal/ui/views/stats.go
+++ b/internal/ui/views/stats.go
@@ -40,6 +40,7 @@ func (v *StatsView) SetContainer(containerID, containerName string) {
 	v.containerName = containerName
 	v.stats = nil
 	v.history = []models.ContainerStats{}
+	v.ready = false // Reset ready so View() shows loading state until StartStreaming is called
 }
 
 // StartStreaming starts streaming stats


### PR DESCRIPTION
  - Move SetContainer calls outside async tea.Cmd to run synchronously
  - Reset ready flag in SetContainer to show loading state properly
  - Add safe containerID slicing to prevent index out of range panic

  This fixes race conditions where View() was called before the async
  command executed, causing nil pointer dereference or stale data access.